### PR TITLE
Cpu data fetching

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "@tailwindcss/vite": "^4.0.13",
     "framer-motion": "^12.5.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "systeminformation": "^5.25.11"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/src/electron/SystemSats.d.ts
+++ b/src/electron/SystemSats.d.ts
@@ -1,0 +1,39 @@
+export type CpuLoad = {
+  avgLoad: number;
+  currentLoad: number;
+  currentLoadUser: number;
+  currentLoadSystem: number;
+  currentLoadNice: number;
+  currentLoadIdle: number;
+  currentLoadIrq: number;
+  currentLoadSteal: number;
+  currentLoadGuest: number;
+  rawCurrentLoad: number;
+  rawCurrentLoadUser: number;
+  rawCurrentLoadSystem: number;
+  rawCurrentLoadNice: number;
+  rawCurrentLoadIdle: number;
+  rawCurrentLoadIrq: number;
+  rawCurrentLoadSteal: number;
+  rawCurrentLoadGuest: number;
+  cpus: Cpus[];
+};
+
+type Cpus = {
+  load: number;
+  loadUser: number;
+  loadSystem: number;
+  loadNice: number;
+  loadIdle: number;
+  loadIrq: number;
+  loadSteal: number;
+  loadGuest: number;
+  rawLoad: number;
+  rawLoadUser: number;
+  rawLoadSystem: number;
+  rawLoadNice: number;
+  rawLoadIdle: number;
+  rawLoadIrq: number;
+  rawLoadSteal: number;
+  rawLoadGuest: number;
+};

--- a/src/electron/ipcLogic.ts
+++ b/src/electron/ipcLogic.ts
@@ -1,0 +1,9 @@
+import { BrowserWindow } from "electron";
+import { getSystemStats } from "./systemStats.js";
+
+export function sendSystemStats(win: BrowserWindow) {
+  setInterval(async () => {
+    const systemStats = await getSystemStats();
+    win.webContents.send("systemStats", systemStats);
+  }, 2000);
+}

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -1,14 +1,20 @@
 import { app, BrowserWindow } from "electron";
 import path from "path";
+import { sendSystemStats } from "./ipcLogic.js";
 
 app.whenReady().then(() => {
   const mainWindow = new BrowserWindow({
     width: 1000,
     height: 800,
     webPreferences: {
-      nodeIntegration: true,
+      nodeIntegration: false,
+      preload: path.join(app.getAppPath(), "/dist/electron/preload.mjs"),
+      contextIsolation: true,
+      sandbox: false,
     },
   });
 
   mainWindow.loadFile(path.join(app.getAppPath(), "/dist/react/index.html"));
+
+  sendSystemStats(mainWindow);
 });

--- a/src/electron/preload.mts
+++ b/src/electron/preload.mts
@@ -1,0 +1,10 @@
+import { contextBridge, ipcRenderer } from "electron";
+
+contextBridge.exposeInMainWorld("electronAPI", {
+  onSystemStats: (cb: any) => {
+    ipcRenderer.on("systemStats", (_, systemStats) => cb(systemStats));
+  },
+  removeSystemStatsListener: (cb: any) => {
+    ipcRenderer.removeListener("systemStats", cb);
+  },
+});

--- a/src/electron/systemStats.ts
+++ b/src/electron/systemStats.ts
@@ -1,0 +1,12 @@
+import si from "systeminformation";
+
+export async function getSystemStats() {
+  const cpuLoad = await si.currentLoad();
+
+  console.log(cpuLoad);
+  return {
+    cpuLoad,
+  };
+}
+
+getSystemStats();

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -1,0 +1,56 @@
+export type CpuLoadData = {
+  cpuLoad: CpuLoad;
+};
+
+export type CpuLoad = {
+  avgLoad: number;
+  currentLoad: number;
+  currentLoadUser: number;
+  currentLoadSystem: number;
+  currentLoadNice: number;
+  currentLoadIdle: number;
+  currentLoadIrq: number;
+  currentLoadSteal: number;
+  currentLoadGuest: number;
+  rawCurrentLoad: number;
+  rawCurrentLoadUser: number;
+  rawCurrentLoadSystem: number;
+  rawCurrentLoadNice: number;
+  rawCurrentLoadIdle: number;
+  rawCurrentLoadIrq: number;
+  rawCurrentLoadSteal: number;
+  rawCurrentLoadGuest: number;
+  cpus: Cpus[];
+};
+
+export type Cpus = {
+  load: number;
+  loadUser: number;
+  loadSystem: number;
+  loadNice: number;
+  loadIdle: number;
+  loadIrq: number;
+  loadSteal: number;
+  loadGuest: number;
+  rawLoad: number;
+  rawLoadUser: number;
+  rawLoadSystem: number;
+  rawLoadNice: number;
+  rawLoadIdle: number;
+  rawLoadIrq: number;
+  rawLoadSteal: number;
+  rawLoadGuest: number;
+};
+
+declare global {
+  interface Window {
+    electronAPI: {
+      onSystemStats: (cb: (systemStats: SystemStats) => void) => void;
+      removeSystemStatsListener: (
+        cb: (systemStats: SystemStats) => void,
+      ) => void;
+    };
+  }
+}
+
+export {};

--- a/src/ui/Dashboard/Cards/SystemInformation/SystemInformationCard.tsx
+++ b/src/ui/Dashboard/Cards/SystemInformation/SystemInformationCard.tsx
@@ -1,8 +1,23 @@
+import { useEffect, useState } from "react";
 import Card from "../../Card";
 import CircularProgressBar from "./CircularProgressBar";
+import { CpuLoadData } from "../../../../types/electron";
 
 export default function SystemInformationCard() {
-  const progressValue = 65;
+  const [progressValue, setProgressValue] = useState(0);
+
+  useEffect(() => {
+    const statsHandler = (CpuLoadData: CpuLoadData) => {
+      setProgressValue(Number(CpuLoadData.cpuLoad.currentLoad.toFixed(2)));
+    };
+
+    window.electronAPI.onSystemStats(statsHandler);
+
+    return () => {
+      window.electronAPI.removeSystemStatsListener(statsHandler);
+    };
+  }, []);
+
   return (
     <Card>
       <div className="h-1/2 basis-1/2">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1888,6 +1888,11 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+systeminformation@^5.25.11:
+  version "5.25.11"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.25.11.tgz#7d47a14dafbc9cf6c21bc02d19a2121a8c770d88"
+  integrity sha512-jI01fn/t47rrLTQB0FTlMCC+5dYx8o0RRF+R4BPiUNsvg5OdY0s9DKMFmJGrx5SwMZQ4cag0Gl6v8oycso9b/g==
+
 tailwindcss@4.0.13, tailwindcss@^4.0.13:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-4.0.13.tgz#093935db2e4b80d245386f69da580528ac5b1b3c"


### PR DESCRIPTION
This merge includes:
1. Added functionality to get cpu data (for now only the cpu load) in the main thread
2. Data gets sent to the ui, which gets hooked into the cpu gauge

Note:
I spent over 7 hours trying to understand why the preload file was acting up and breaking the entire project. I set sandbox to `false` and everything magically started to work. For now it should be kept off (for my sanity) 

This should fix #3